### PR TITLE
fix(dragonruby): use Geometry module instead of args.geometry for consistency

### DIFF
--- a/plugins/dragonruby/.claude-plugin/plugin.json
+++ b/plugins/dragonruby/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dragonruby",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "DragonRuby Game Toolkit patterns for 2D game development",
   "author": {
     "name": "hoblin"

--- a/plugins/dragonruby/skills/dragonruby/SKILL.md
+++ b/plugins/dragonruby/skills/dragonruby/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: DragonRuby Game Toolkit
 description: This skill should be used when the user asks to "create a game", "make a game", "game development", "dragonruby", "drgtk", "game loop", "tick method", "sprite rendering", "game state", or mentions args.outputs, args.state, args.inputs, coordinate system, collision detection, animation frames, or scene management. Should also be used when editing DragonRuby game files, working on 2D game logic, or discussing game performance optimization.
-version: 1.0.0
+version: 1.0.1
 ---
 
 # DragonRuby Game Toolkit
@@ -39,7 +39,7 @@ end
 | `args.state` | Persistent game data storage |
 | `args.inputs` | Keyboard, mouse, controller input |
 | `args.grid` | Screen dimensions (1280x720) |
-| `args.geometry` | Collision detection helpers |
+| `Geometry` | Collision detection helpers |
 
 ### Coordinate System
 
@@ -137,7 +137,7 @@ args.inputs.mouse.inside_rect?(rect)  # Collision check
 ## Collision Detection
 
 ```ruby
-if args.geometry.intersect_rect?(player, enemy)
+if Geometry.intersect_rect?(player, enemy)
   enemy.dead = true
   args.state.score += 1
 end

--- a/plugins/dragonruby/skills/dragonruby/examples/entities/collision_detection.rb
+++ b/plugins/dragonruby/skills/dragonruby/examples/entities/collision_detection.rb
@@ -20,13 +20,13 @@ def tick(args)
   end
 
   # Method 2: find_intersect_rect - returns first collision (faster)
-  collision = args.geometry.find_intersect_rect(
+  collision = Geometry.find_intersect_rect(
     args.state.player,
     args.state.enemies
   )
 
   # Method 3: find_all_intersect_rect - returns all collisions
-  all_hits = args.geometry.find_all_intersect_rect(
+  all_hits = Geometry.find_all_intersect_rect(
     args.state.player,
     args.state.enemies
   )

--- a/plugins/dragonruby/skills/dragonruby/examples/entities/entity_lifecycle.rb
+++ b/plugins/dragonruby/skills/dragonruby/examples/entities/entity_lifecycle.rb
@@ -47,7 +47,7 @@ def check_collisions(args)
     args.state.targets.each do |target|
       next if target.dead
 
-      if args.geometry.intersect_rect?(bullet, target)
+      if Geometry.intersect_rect?(bullet, target)
         bullet.dead = true
         target.dead = true
       end

--- a/plugins/dragonruby/skills/dragonruby/references/audio.md
+++ b/plugins/dragonruby/skills/dragonruby/references/audio.md
@@ -30,7 +30,7 @@ if args.inputs.keyboard.key_down.space
 end
 
 # On collision
-if args.geometry.intersect_rect?(bullet, enemy)
+if Geometry.intersect_rect?(bullet, enemy)
   args.outputs.sounds << "sounds/hit.wav"
   enemy.dead = true
 end

--- a/plugins/dragonruby/skills/dragonruby/references/core.md
+++ b/plugins/dragonruby/skills/dragonruby/references/core.md
@@ -92,7 +92,7 @@ The `args` parameter contains everything needed for the game:
 | `args.state` | Persistent game data |
 | `args.inputs` | Keyboard/mouse/controller |
 | `args.grid` | Screen dimensions |
-| `args.geometry` | Collision helpers |
+| `Geometry` | Collision helpers (also `args.geometry`) |
 | `args.audio` | Sound playback |
 
 ## args.state - Game State

--- a/plugins/dragonruby/skills/dragonruby/references/entities.md
+++ b/plugins/dragonruby/skills/dragonruby/references/entities.md
@@ -145,7 +145,7 @@ if player.intersect_rect?(enemy)
 end
 
 # Module method
-if args.geometry.intersect_rect?(player, enemy)
+if Geometry.intersect_rect?(player, enemy)
   handle_collision
 end
 
@@ -159,7 +159,7 @@ end
 
 ```ruby
 # Returns first intersecting entity or nil
-hit = args.geometry.find_intersect_rect(bullet, args.state.enemies)
+hit = Geometry.find_intersect_rect(bullet, args.state.enemies)
 if hit
   hit.dead = true
 end
@@ -169,7 +169,7 @@ end
 
 ```ruby
 # Returns array (empty if no collisions)
-hits = args.geometry.find_all_intersect_rect(explosion, args.state.enemies)
+hits = Geometry.find_all_intersect_rect(explosion, args.state.enemies)
 hits.each { |enemy| enemy.health -= 50 }
 ```
 
@@ -177,7 +177,7 @@ hits.each { |enemy| enemy.health -= 50 }
 
 ```ruby
 # Iterate through all collision pairs
-args.geometry.each_intersect_rect(bullets, enemies) do |bullet, enemy|
+Geometry.each_intersect_rect(bullets, enemies) do |bullet, enemy|
   bullet.dead = true
   enemy.health -= bullet.damage
 end
@@ -188,7 +188,7 @@ end
 ```ruby
 args.state.bullets.each do |bullet|
   args.state.enemies.each do |enemy|
-    if args.geometry.intersect_rect?(bullet, enemy)
+    if Geometry.intersect_rect?(bullet, enemy)
       bullet.dead = true
       enemy.dead = true
     end
@@ -200,10 +200,10 @@ end
 
 ```ruby
 # Create once for static/semi-static entities
-args.state.quad_tree ||= args.geometry.quad_tree_create(args.state.terrain)
+args.state.quad_tree ||= Geometry.quad_tree_create(args.state.terrain)
 
 # Fast collision lookup
-hit = args.geometry.find_intersect_rect_quad_tree(
+hit = Geometry.find_intersect_rect_quad_tree(
   args.state.player,
   args.state.quad_tree
 )
@@ -227,7 +227,7 @@ args.state.bullets.each do |bullet|
 
   # Mark on collision
   args.state.enemies.each do |enemy|
-    if args.geometry.intersect_rect?(bullet, enemy)
+    if Geometry.intersect_rect?(bullet, enemy)
       bullet.dead = true
       enemy.dead = true
     end
@@ -295,6 +295,8 @@ end
 ```
 
 ## Geometry API Reference
+
+Access via `Geometry.*` (preferred) or `args.geometry.*`. Instance methods also available as mixins on Hash/Array/Entity.
 
 | Method | Returns | Use Case |
 |--------|---------|----------|
@@ -378,7 +380,7 @@ args.state.bullets.each do |bullet|
   bullet.x += bullet.speed
   # No check if already dead - wastes cycles
   args.state.enemies.each do |enemy|
-    if args.geometry.intersect_rect?(bullet, enemy)
+    if Geometry.intersect_rect?(bullet, enemy)
       bullet.dead = true
       enemy.dead = true
     end
@@ -424,7 +426,7 @@ def check_collisions(args)
     args.state.enemies.each do |enemy|
       next if enemy.dead
 
-      if args.geometry.intersect_rect?(bullet, enemy)
+      if Geometry.intersect_rect?(bullet, enemy)
         bullet.dead = true
         enemy.dead = true
         args.state.score ||= 0


### PR DESCRIPTION
## Summary

- Standardized API references to use `Geometry.*` (global module) instead of `args.geometry.*` for consistency with `Easing.*` pattern
- Updated documentation to note both access patterns are valid
- Bumped skill and plugin versions to 1.0.1

## Changes

- 18 occurrences of `args.geometry.*` replaced with `Geometry.*` across 6 files
- Added note in Geometry API Reference section explaining both patterns
- Updated `core.md` table to show `Geometry` with `args.geometry` as alternative

## Test plan

- [x] `grep -r "args\.geometry" plugins/dragonruby/` shows no code examples using old pattern
- [x] `claude plugin validate plugins/dragonruby/` passes