### PR TITLE
fix(skills): use YAML block scalars for Codex compatibility

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,42 +17,42 @@
     {
       "name": "rspec",
       "description": "RSpec and FactoryBot testing patterns for Rails",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "source": "./plugins/rspec",
       "category": "testing"
     },
     {
       "name": "draper",
       "description": "Draper decorator patterns for Rails view logic",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "source": "./plugins/draper",
       "category": "patterns"
     },
     {
       "name": "activerecord",
       "description": "ActiveRecord patterns for Rails models and queries",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "source": "./plugins/activerecord",
       "category": "database"
     },
     {
       "name": "mcp",
       "description": "MCP server development with Ruby SDK",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "source": "./plugins/mcp",
       "category": "integrations"
     },
     {
       "name": "dragonruby",
       "description": "DragonRuby Game Toolkit patterns for 2D game development",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "source": "./plugins/dragonruby",
       "category": "game-development"
     },
     {
       "name": "ratatui-ruby",
       "description": "RatatuiRuby TUI development for terminal user interfaces",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "source": "./plugins/ratatui-ruby",
       "category": "tui-development"
     },

--- a/plugins/activerecord/.claude-plugin/plugin.json
+++ b/plugins/activerecord/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "activerecord",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "ActiveRecord patterns for Rails models and queries",
   "author": { "name": "hoblin" }
 }

--- a/plugins/activerecord/skills/activerecord/SKILL.md
+++ b/plugins/activerecord/skills/activerecord/SKILL.md
@@ -1,7 +1,18 @@
 ---
 name: activerecord
-description: This skill should be used when the user asks to "write a migration", "add a column", "add column to table", "create an index", "add a foreign key", "set up associations", "fix N+1 queries", "optimize queries", "add validations", "create callbacks", "use eager loading", or mentions ActiveRecord, belongs_to, has_many, has_one, :through associations, polymorphic associations, inverse_of, touch: true, counter_cache, dependent: destroy, where clauses, scopes, includes, preload, eager_load, joins, find_each, batch processing, counter caches, foreign key constraints, or database constraints. Should also be used when editing *_model.rb files, working in app/models/ directory, db/migrate/, discussing query performance, N+1 prevention, validation vs constraint decisions, or reviewing database schema design.
-version: 1.0.1
+description: >-
+  This skill should be used when the user asks to "write a migration", "add a
+  column", "add column to table", "create an index", "add a foreign key", "set
+  up associations", "fix N+1 queries", "optimize queries", "add validations",
+  "create callbacks", "use eager loading", or mentions ActiveRecord, belongs_to,
+  has_many, has_one, :through associations, polymorphic associations, inverse_of,
+  touch: true, counter_cache, dependent: destroy, where clauses, scopes,
+  includes, preload, eager_load, joins, find_each, batch processing, counter
+  caches, foreign key constraints, or database constraints. Should also be used
+  when editing *_model.rb files, working in app/models/ directory, db/migrate/,
+  discussing query performance, N+1 prevention, validation vs constraint
+  decisions, or reviewing database schema design.
+version: 1.0.2
 ---
 
 # ActiveRecord

--- a/plugins/dragonruby/.claude-plugin/plugin.json
+++ b/plugins/dragonruby/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dragonruby",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "DragonRuby Game Toolkit patterns for 2D game development",
   "author": {
     "name": "hoblin"

--- a/plugins/dragonruby/skills/dragonruby/SKILL.md
+++ b/plugins/dragonruby/skills/dragonruby/SKILL.md
@@ -1,7 +1,13 @@
 ---
 name: dragonruby
-description: This skill should be used when the user asks to "create a game", "make a game", "game development", "dragonruby", "drgtk", "game loop", "tick method", "sprite rendering", "game state", or mentions args.outputs, args.state, args.inputs, coordinate system, collision detection, animation frames, or scene management. Should also be used when editing DragonRuby game files, working on 2D game logic, or discussing game performance optimization.
-version: 1.0.4
+description: >-
+  This skill should be used when the user asks to "create a game", "make a
+  game", "game development", "dragonruby", "drgtk", "game loop", "tick method",
+  "sprite rendering", "game state", or mentions args.outputs, args.state,
+  args.inputs, coordinate system, collision detection, animation frames, or
+  scene management. Should also be used when editing DragonRuby game files,
+  working on 2D game logic, or discussing game performance optimization.
+version: 1.0.5
 ---
 
 # DragonRuby Game Toolkit

--- a/plugins/draper/.claude-plugin/plugin.json
+++ b/plugins/draper/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "draper",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Draper decorator patterns for Rails view logic",
   "author": { "name": "hoblin" }
 }

--- a/plugins/draper/skills/draper-decorators/SKILL.md
+++ b/plugins/draper/skills/draper-decorators/SKILL.md
@@ -1,7 +1,15 @@
 ---
 name: draper-decorators
-description: This skill should be used when the user asks to "create a decorator", "write a decorator", "move logic into decorator", "clean logic out of the view", "isn't it decorator logic", "test a decorator", or mentions Draper, keeping views clean, or representation logic in decorators. Should also be used when editing *_decorator.rb files, working in app/decorators/ directory, questioning where formatting methods belong (models vs decorators vs views), or discussing methods like full_name, formatted_*, display_* that don't belong in models. Provides guidance on Draper gem best practices for Rails applications.
-version: 1.1.1
+description: >-
+  This skill should be used when the user asks to "create a decorator", "write a
+  decorator", "move logic into decorator", "clean logic out of the view", "isn't
+  it decorator logic", "test a decorator", or mentions Draper, keeping views
+  clean, or representation logic in decorators. Should also be used when editing
+  *_decorator.rb files, working in app/decorators/ directory, questioning where
+  formatting methods belong (models vs decorators vs views), or discussing
+  methods like full_name, formatted_*, display_* that don't belong in models.
+  Provides guidance on Draper gem best practices for Rails applications.
+version: 1.1.2
 ---
 
 # Draper Decorators for Rails

--- a/plugins/mcp/.claude-plugin/plugin.json
+++ b/plugins/mcp/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "MCP server development with Ruby SDK",
   "author": { "name": "hoblin" }
 }

--- a/plugins/mcp/skills/mcp-server/SKILL.md
+++ b/plugins/mcp/skills/mcp-server/SKILL.md
@@ -1,7 +1,13 @@
 ---
 name: mcp-server
-version: 1.0.1
-description: This skill should be used when the user asks to "create an MCP server", "build MCP tools", "define MCP prompts", "register MCP resources", "implement Model Context Protocol", or mentions the mcp gem, MCP::Server, MCP::Tool, JSON-RPC transport, stdio transport, or streamable HTTP transport. Should also be used when editing MCP server files, working with tool/prompt/resource definitions, or discussing LLM tool integrations in Ruby.
+version: 1.0.2
+description: >-
+  This skill should be used when the user asks to "create an MCP server", "build
+  MCP tools", "define MCP prompts", "register MCP resources", "implement Model
+  Context Protocol", or mentions the mcp gem, MCP::Server, MCP::Tool, JSON-RPC
+  transport, stdio transport, or streamable HTTP transport. Should also be used
+  when editing MCP server files, working with tool/prompt/resource definitions,
+  or discussing LLM tool integrations in Ruby.
 ---
 
 # MCP Ruby SDK - Server Development Guide

--- a/plugins/ratatui-ruby/.claude-plugin/plugin.json
+++ b/plugins/ratatui-ruby/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ratatui-ruby",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "RatatuiRuby TUI development for terminal user interfaces",
   "author": {
     "name": "hoblin"

--- a/plugins/ratatui-ruby/skills/ratatui-ruby/SKILL.md
+++ b/plugins/ratatui-ruby/skills/ratatui-ruby/SKILL.md
@@ -1,7 +1,14 @@
 ---
 name: ratatui-ruby
-description: This skill should be used when the user asks to "create a TUI", "terminal interface", "terminal UI", "ratatui", "ratatui-ruby", "inline viewport", "full-screen terminal app", "terminal widgets", "tui.draw", "tui.poll_event", or mentions RatatuiRuby.run, managed loop, terminal rendering, Tea MVU, or building CLI applications with rich UI elements. Should also be used when editing RatatuiRuby application files, working with terminal widgets, or discussing TUI architecture patterns.
-version: 1.2.1
+description: >-
+  This skill should be used when the user asks to "create a TUI", "terminal
+  interface", "terminal UI", "ratatui", "ratatui-ruby", "inline viewport",
+  "full-screen terminal app", "terminal widgets", "tui.draw", "tui.poll_event",
+  or mentions RatatuiRuby.run, managed loop, terminal rendering, Tea MVU, or
+  building CLI applications with rich UI elements. Should also be used when
+  editing RatatuiRuby application files, working with terminal widgets, or
+  discussing TUI architecture patterns.
+version: 1.2.2
 ---
 
 # RatatuiRuby

--- a/plugins/rspec/.claude-plugin/plugin.json
+++ b/plugins/rspec/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rspec",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "RSpec and FactoryBot testing patterns for Rails",
   "author": { "name": "hoblin" }
 }

--- a/plugins/rspec/skills/rspec/SKILL.md
+++ b/plugins/rspec/skills/rspec/SKILL.md
@@ -1,7 +1,15 @@
 ---
 name: rspec
-version: 1.1.1
-description: This skill should be used when the user asks to "write specs", "create spec", "add RSpec tests", "fix failing spec", or mentions RSpec, describe blocks, it blocks, expect syntax, test doubles, or matchers. Should also be used when editing *_spec.rb files, working in spec/ directory, planning implementation phases that include tests (TDD/RGRC workflow), writing Testing Strategy or Success Criteria sections, discussing unit or integration tests, or reviewing spec output and test failures. Comprehensive RSpec and FactoryBot reference with best practices, ready-to-use patterns, and examples.
+version: 1.1.2
+description: >-
+  This skill should be used when the user asks to "write specs", "create spec",
+  "add RSpec tests", "fix failing spec", or mentions RSpec, describe blocks, it
+  blocks, expect syntax, test doubles, or matchers. Should also be used when
+  editing *_spec.rb files, working in spec/ directory, planning implementation
+  phases that include tests (TDD/RGRC workflow), writing Testing Strategy or
+  Success Criteria sections, discussing unit or integration tests, or reviewing
+  spec output and test failures. Comprehensive RSpec and FactoryBot reference
+  with best practices, ready-to-use patterns, and examples.
 ---
 
 # RSpec Testing


### PR DESCRIPTION
## Issue

YAML frontmatter descriptions are written as plain, unquoted scalar values, but they contain substrings like touch: true and dependent: destroy. In YAML, a colon followed by a space (: ) inside an unquoted value is parsed as a mapping separator, not literal text. 

That makes Codex parsing the skills fail with errors like:

> invalid YAML: mapping values are not allowed in this context

## Summary

- Convert all 6 SKILL.md `description` fields from inline plain-text values to `>-` folded block scalars
- Fixes invalid YAML caused by colon-space patterns (`touch: true`, `dependent: destroy`) being parsed as mapping separators
- Patch-bumps all skill versions

## Affected skills

| Skill | Version |
|---|---|
| activerecord | 1.0.1 → 1.0.2 |
| dragonruby | 1.0.4 → 1.0.5 |
| draper-decorators | 1.1.1 → 1.1.2 |
| mcp-server | 1.0.1 → 1.0.2 |
| ratatui-ruby | 1.2.1 → 1.2.2 |
| rspec | 1.1.1 → 1.1.2 |

## Test plan

- [x] Validated all 6 frontmatter blocks parse as valid YAML (python3 yaml.safe_load)
- [x] Placed activerecord skill in `.claude/skills/activerecord-test/SKILL.md` and confirmed Claude Code detected it with correct description
- [x] Description text preserved exactly — only formatting changed