### PR TITLE
refactor(rpi): migrate commands to skills format

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -59,7 +59,7 @@
     {
       "name": "rpi",
       "description": "RPI workflow: Research, Planning, Implementation with context engineering",
-      "version": "1.8.11",
+      "version": "1.9.0",
       "source": "./plugins/rpi",
       "category": "workflow"
     }

--- a/plugins/activerecord/skills/activerecord/SKILL.md
+++ b/plugins/activerecord/skills/activerecord/SKILL.md
@@ -1,7 +1,18 @@
 ---
 name: activerecord
-description: This skill should be used when the user asks to "write a migration", "add a column", "add column to table", "create an index", "add a foreign key", "set up associations", "fix N+1 queries", "optimize queries", "add validations", "create callbacks", "use eager loading", or mentions ActiveRecord, belongs_to, has_many, has_one, :through associations, polymorphic associations, inverse_of, touch: true, counter_cache, dependent: destroy, where clauses, scopes, includes, preload, eager_load, joins, find_each, batch processing, counter caches, foreign key constraints, or database constraints. Should also be used when editing *_model.rb files, working in app/models/ directory, db/migrate/, discussing query performance, N+1 prevention, validation vs constraint decisions, or reviewing database schema design.
-version: 1.0.1
+description: >-
+  This skill should be used when the user asks to "write a migration", "add a
+  column", "add column to table", "create an index", "add a foreign key", "set
+  up associations", "fix N+1 queries", "optimize queries", "add validations",
+  "create callbacks", "use eager loading", or mentions ActiveRecord, belongs_to,
+  has_many, has_one, :through associations, polymorphic associations, inverse_of,
+  touch: true, counter_cache, dependent: destroy, where clauses, scopes,
+  includes, preload, eager_load, joins, find_each, batch processing, counter
+  caches, foreign key constraints, or database constraints. Should also be used
+  when editing *_model.rb files, working in app/models/ directory, db/migrate/,
+  discussing query performance, N+1 prevention, validation vs constraint
+  decisions, or reviewing database schema design.
+version: 1.0.2
 ---
 
 # ActiveRecord

--- a/plugins/dragonruby/skills/dragonruby/SKILL.md
+++ b/plugins/dragonruby/skills/dragonruby/SKILL.md
@@ -1,7 +1,13 @@
 ---
 name: dragonruby
-description: This skill should be used when the user asks to "create a game", "make a game", "game development", "dragonruby", "drgtk", "game loop", "tick method", "sprite rendering", "game state", or mentions args.outputs, args.state, args.inputs, coordinate system, collision detection, animation frames, or scene management. Should also be used when editing DragonRuby game files, working on 2D game logic, or discussing game performance optimization.
-version: 1.0.4
+description: >-
+  This skill should be used when the user asks to "create a game", "make a
+  game", "game development", "dragonruby", "drgtk", "game loop", "tick method",
+  "sprite rendering", "game state", or mentions args.outputs, args.state,
+  args.inputs, coordinate system, collision detection, animation frames, or
+  scene management. Should also be used when editing DragonRuby game files,
+  working on 2D game logic, or discussing game performance optimization.
+version: 1.0.5
 ---
 
 # DragonRuby Game Toolkit

--- a/plugins/draper/skills/draper-decorators/SKILL.md
+++ b/plugins/draper/skills/draper-decorators/SKILL.md
@@ -1,7 +1,15 @@
 ---
 name: draper-decorators
-description: This skill should be used when the user asks to "create a decorator", "write a decorator", "move logic into decorator", "clean logic out of the view", "isn't it decorator logic", "test a decorator", or mentions Draper, keeping views clean, or representation logic in decorators. Should also be used when editing *_decorator.rb files, working in app/decorators/ directory, questioning where formatting methods belong (models vs decorators vs views), or discussing methods like full_name, formatted_*, display_* that don't belong in models. Provides guidance on Draper gem best practices for Rails applications.
-version: 1.1.1
+description: >-
+  This skill should be used when the user asks to "create a decorator", "write a
+  decorator", "move logic into decorator", "clean logic out of the view", "isn't
+  it decorator logic", "test a decorator", or mentions Draper, keeping views
+  clean, or representation logic in decorators. Should also be used when editing
+  *_decorator.rb files, working in app/decorators/ directory, questioning where
+  formatting methods belong (models vs decorators vs views), or discussing
+  methods like full_name, formatted_*, display_* that don't belong in models.
+  Provides guidance on Draper gem best practices for Rails applications.
+version: 1.1.2
 ---
 
 # Draper Decorators for Rails

--- a/plugins/mcp/skills/mcp-server/SKILL.md
+++ b/plugins/mcp/skills/mcp-server/SKILL.md
@@ -1,7 +1,13 @@
 ---
 name: mcp-server
-version: 1.0.1
-description: This skill should be used when the user asks to "create an MCP server", "build MCP tools", "define MCP prompts", "register MCP resources", "implement Model Context Protocol", or mentions the mcp gem, MCP::Server, MCP::Tool, JSON-RPC transport, stdio transport, or streamable HTTP transport. Should also be used when editing MCP server files, working with tool/prompt/resource definitions, or discussing LLM tool integrations in Ruby.
+version: 1.0.2
+description: >-
+  This skill should be used when the user asks to "create an MCP server", "build
+  MCP tools", "define MCP prompts", "register MCP resources", "implement Model
+  Context Protocol", or mentions the mcp gem, MCP::Server, MCP::Tool, JSON-RPC
+  transport, stdio transport, or streamable HTTP transport. Should also be used
+  when editing MCP server files, working with tool/prompt/resource definitions,
+  or discussing LLM tool integrations in Ruby.
 ---
 
 # MCP Ruby SDK - Server Development Guide

--- a/plugins/ratatui-ruby/skills/ratatui-ruby/SKILL.md
+++ b/plugins/ratatui-ruby/skills/ratatui-ruby/SKILL.md
@@ -1,7 +1,14 @@
 ---
 name: ratatui-ruby
-description: This skill should be used when the user asks to "create a TUI", "terminal interface", "terminal UI", "ratatui", "ratatui-ruby", "inline viewport", "full-screen terminal app", "terminal widgets", "tui.draw", "tui.poll_event", or mentions RatatuiRuby.run, managed loop, terminal rendering, Tea MVU, or building CLI applications with rich UI elements. Should also be used when editing RatatuiRuby application files, working with terminal widgets, or discussing TUI architecture patterns.
-version: 1.2.1
+description: >-
+  This skill should be used when the user asks to "create a TUI", "terminal
+  interface", "terminal UI", "ratatui", "ratatui-ruby", "inline viewport",
+  "full-screen terminal app", "terminal widgets", "tui.draw", "tui.poll_event",
+  or mentions RatatuiRuby.run, managed loop, terminal rendering, Tea MVU, or
+  building CLI applications with rich UI elements. Should also be used when
+  editing RatatuiRuby application files, working with terminal widgets, or
+  discussing TUI architecture patterns.
+version: 1.2.2
 ---
 
 # RatatuiRuby

--- a/plugins/rpi/.claude-plugin/plugin.json
+++ b/plugins/rpi/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rpi",
-  "version": "1.8.11",
-  "description": "RPI workflow: Research, Planning, Implementation. Context engineering system with structured agents and commands for AI-assisted development.",
+  "version": "1.9.0",
+  "description": "RPI workflow: Research, Planning, Implementation. Context engineering system with structured agents and skills for AI-assisted development.",
   "author": {
     "name": "hoblin"
   },
@@ -15,5 +15,6 @@
     "implementation",
     "handoffs",
     "session-continuity"
-  ]
+  ],
+  "skills": "./skills/"
 }

--- a/plugins/rpi/skills/commit/SKILL.md
+++ b/plugins/rpi/skills/commit/SKILL.md
@@ -1,5 +1,8 @@
 ---
-description: Create git commits with user approval and no Claude attribution
+name: commit
+description: >-
+  Create git commits with user approval and no Claude attribution
+version: 1.0.0
 ---
 
 # Commit Changes

--- a/plugins/rpi/skills/create_handoff/SKILL.md
+++ b/plugins/rpi/skills/create_handoff/SKILL.md
@@ -1,5 +1,8 @@
 ---
-description: Create handoff document for transferring work to another session
+name: create_handoff
+description: >-
+  Create handoff document for transferring work to another session
+version: 1.0.0
 ---
 
 # Create Handoff

--- a/plugins/rpi/skills/create_note/SKILL.md
+++ b/plugins/rpi/skills/create_note/SKILL.md
@@ -1,5 +1,8 @@
 ---
-description: Capture findings or context as a persistent note in the thoughts system
+name: create_note
+description: >-
+  Capture findings or context as a persistent note in the thoughts system
+version: 1.0.0
 ---
 
 # Create Note

--- a/plugins/rpi/skills/create_plan/SKILL.md
+++ b/plugins/rpi/skills/create_plan/SKILL.md
@@ -1,5 +1,8 @@
 ---
-description: Create detailed implementation plans through interactive research and iteration
+name: create_plan
+description: >-
+  Create detailed implementation plans through interactive research and iteration
+version: 1.0.0
 model: opus
 ---
 

--- a/plugins/rpi/skills/feature/SKILL.md
+++ b/plugins/rpi/skills/feature/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: feature
+description: >-
+  One-shot feature implementation from branch creation to PR readiness with
+  research, testing, and CI monitoring
+version: 1.0.0
+---
+
 ## Input Format
 
 ```

--- a/plugins/rpi/skills/implement_plan/SKILL.md
+++ b/plugins/rpi/skills/implement_plan/SKILL.md
@@ -1,5 +1,8 @@
 ---
-description: Implement technical plans from ./thoughts/shared/plans with verification
+name: implement_plan
+description: >-
+  Implement technical plans from ./thoughts/shared/plans with verification
+version: 1.0.0
 ---
 
 # Implement Plan

--- a/plugins/rpi/skills/iterate_plan/SKILL.md
+++ b/plugins/rpi/skills/iterate_plan/SKILL.md
@@ -1,5 +1,8 @@
 ---
-description: Iterate on existing implementation plans with thorough research and updates
+name: iterate_plan
+description: >-
+  Iterate on existing implementation plans with thorough research and updates
+version: 1.0.0
 model: opus
 ---
 

--- a/plugins/rpi/skills/research_codebase/SKILL.md
+++ b/plugins/rpi/skills/research_codebase/SKILL.md
@@ -1,5 +1,8 @@
 ---
-description: Document codebase as-is with thoughts directory for historical context
+name: research_codebase
+description: >-
+  Document codebase as-is with thoughts directory for historical context
+version: 1.0.0
 model: opus
 ---
 

--- a/plugins/rpi/skills/resume_handoff/SKILL.md
+++ b/plugins/rpi/skills/resume_handoff/SKILL.md
@@ -1,5 +1,8 @@
 ---
-description: Resume work from handoff document with context analysis and validation
+name: resume_handoff
+description: >-
+  Resume work from handoff document with context analysis and validation
+version: 1.0.0
 ---
 
 # Resume work from a handoff document

--- a/plugins/rpi/skills/review-pr/SKILL.md
+++ b/plugins/rpi/skills/review-pr/SKILL.md
@@ -1,5 +1,10 @@
 ---
-description: Multi-agent PR review with four modes (review, re-review, self-review, address-feedback) - spawns parallel subagents, saves diff to /tmp for context efficiency, supports file exclusion patterns
+name: review-pr
+description: >-
+  Multi-agent PR review with four modes (review, re-review, self-review,
+  address-feedback) - spawns parallel subagents, saves diff to /tmp for context
+  efficiency, supports file exclusion patterns
+version: 1.0.0
 ---
 
 ## Input Format

--- a/plugins/rpi/skills/thoughts_init/SKILL.md
+++ b/plugins/rpi/skills/thoughts_init/SKILL.md
@@ -1,5 +1,8 @@
 ---
-description: Initialize thoughts system for current repository
+name: thoughts_init
+description: >-
+  Initialize thoughts system for current repository
+version: 1.0.0
 ---
 
 # Initialize Thoughts System

--- a/plugins/rpi/skills/validate_plan/SKILL.md
+++ b/plugins/rpi/skills/validate_plan/SKILL.md
@@ -1,5 +1,8 @@
 ---
-description: Validate implementation against plan, verify success criteria, identify issues
+name: validate_plan
+description: >-
+  Validate implementation against plan, verify success criteria, identify issues
+version: 1.0.0
 ---
 
 # Validate Plan

--- a/plugins/rspec/skills/rspec/SKILL.md
+++ b/plugins/rspec/skills/rspec/SKILL.md
@@ -1,7 +1,15 @@
 ---
 name: rspec
-version: 1.1.1
-description: This skill should be used when the user asks to "write specs", "create spec", "add RSpec tests", "fix failing spec", or mentions RSpec, describe blocks, it blocks, expect syntax, test doubles, or matchers. Should also be used when editing *_spec.rb files, working in spec/ directory, planning implementation phases that include tests (TDD/RGRC workflow), writing Testing Strategy or Success Criteria sections, discussing unit or integration tests, or reviewing spec output and test failures. Comprehensive RSpec and FactoryBot reference with best practices, ready-to-use patterns, and examples.
+version: 1.1.2
+description: >-
+  This skill should be used when the user asks to "write specs", "create spec",
+  "add RSpec tests", "fix failing spec", or mentions RSpec, describe blocks, it
+  blocks, expect syntax, test doubles, or matchers. Should also be used when
+  editing *_spec.rb files, working in spec/ directory, planning implementation
+  phases that include tests (TDD/RGRC workflow), writing Testing Strategy or
+  Success Criteria sections, discussing unit or integration tests, or reviewing
+  spec output and test failures. Comprehensive RSpec and FactoryBot reference
+  with best practices, ready-to-use patterns, and examples.
 ---
 
 # RSpec Testing


### PR DESCRIPTION
## Summary
- Convert all 12 rpi commands from obsolete `commands/` directory to `skills/*/SKILL.md` format per plugin docs
- Add YAML `>-` block scalars to all existing skill descriptions (fixes colon-space parsing issues)
- Add `"skills": "./skills/"` to rpi plugin.json, bump to 1.9.0

## Details
All `/rpi:*` invocations unchanged — skill directory names match old command names. Each SKILL.md gets proper frontmatter (`name`, `description`, `version`). Skills with `model: opus` retain it (create_plan, iterate_plan, research_codebase). Agents and templates untouched.

## Test plan
- [ ] Verify `/rpi:commit`, `/rpi:create_plan`, `/rpi:review-pr` etc. still invoke correctly
- [ ] Confirm skill descriptions appear in system-reminder listing
- [ ] Check `model: opus` skills still use opus model