### PR TITLE
fix(rpi): pin agents to sonnet alias (1.9.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -59,7 +59,7 @@
     {
       "name": "rpi",
       "description": "RPI workflow: Research, Planning, Implementation with context engineering",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "source": "./plugins/rpi",
       "category": "workflow"
     }

--- a/plugins/rpi/.claude-plugin/plugin.json
+++ b/plugins/rpi/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rpi",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "RPI workflow: Research, Planning, Implementation. Context engineering system with structured agents and commands for AI-assisted development.",
   "author": {
     "name": "hoblin"

--- a/plugins/rpi/agents/codebase-analyzer.md
+++ b/plugins/rpi/agents/codebase-analyzer.md
@@ -2,7 +2,7 @@
 name: codebase-analyzer
 description: Analyzes codebase implementation details. Call the rpi:codebase-analyzer agent when you need to find detailed information about specific components. As always, the more detailed your request prompt, the better! :)
 tools: Read, Grep, Glob, LS
-model: claude-sonnet-4-5
+model: sonnet
 ---
 
 You are a specialist at understanding HOW code works. Your job is to analyze implementation details, trace data flow, and explain technical workings with precise file:line references.

--- a/plugins/rpi/agents/codebase-pattern-finder.md
+++ b/plugins/rpi/agents/codebase-pattern-finder.md
@@ -2,7 +2,7 @@
 name: codebase-pattern-finder
 description: rpi:codebase-pattern-finder is a useful subagent_type for finding similar implementations, usage examples, or existing patterns that can be modeled after. It will give you concrete code examples based on what you're looking for!
 tools: Grep, Glob, Read, LS
-model: claude-sonnet-4-5
+model: sonnet
 ---
 
 You are a specialist at finding code patterns and examples in the codebase. Your job is to locate similar implementations that can serve as templates or inspiration for new work.

--- a/plugins/rpi/agents/documentation-researcher.md
+++ b/plugins/rpi/agents/documentation-researcher.md
@@ -2,7 +2,7 @@
 name: documentation-researcher
 description: Need to learn how to use a library, gem, or framework? This agent fetches up-to-date official documentation via Context7, understands your specific use case, and provides ready-to-use code examples. Great for setup guides, API usage, Rails methods, gem configuration, and implementation patterns.
 tools: mcp__context7__resolve-library-id, mcp__context7__get-library-docs, WebSearch, WebFetch, TodoWrite
-model: claude-sonnet-4-5
+model: sonnet
 color: cyan
 ---
 

--- a/plugins/rpi/agents/thoughts-analyzer.md
+++ b/plugins/rpi/agents/thoughts-analyzer.md
@@ -2,7 +2,7 @@
 name: thoughts-analyzer
 description: Extracts decisions and actionable insights from project history documents. Plans in thoughts/ contain problems, solutions, and reasoning - but mixed with exploration noise. Returns: what was decided, why, constraints identified, and whether conclusions are still valid. Filters noise, returns only high-value information.
 tools: Read, Grep, Glob, LS
-model: claude-sonnet-4-5
+model: sonnet
 ---
 
 You are a specialist at extracting HIGH-VALUE insights from thoughts documents. Your job is to deeply analyze documents and return only the most relevant, actionable information while filtering out noise.

--- a/plugins/rpi/agents/web-search-researcher.md
+++ b/plugins/rpi/agents/web-search-researcher.md
@@ -3,7 +3,7 @@ name: web-search-researcher
 description: Do you find yourself desiring information that you don't quite feel well-trained (confident) on? Information that is modern and potentially only discoverable on the web? Use the rpi:web-search-researcher subagent_type today to find any and all answers to your questions! It will research deeply to figure out and attempt to answer your questions! If you aren't immediately satisfied you can get your money back! (Not really - but you can re-run rpi:web-search-researcher with an altered prompt in the event you're not satisfied the first time)
 tools: WebSearch, WebFetch, TodoWrite, Read, Grep, Glob, LS
 color: yellow
-model: claude-sonnet-4-5
+model: sonnet
 maxTurns: 25
 ---
 


### PR DESCRIPTION
## Summary

- All 5 rpi agents (`thoughts-analyzer`, `codebase-analyzer`, `codebase-pattern-finder`, `documentation-researcher`, `web-search-researcher`) had `model: claude-sonnet-4-5` pinned in their frontmatter, locking them to the older Sonnet generation.
- Switched to the `sonnet` alias so they track the latest released Sonnet (currently 4.6) — same convention already used by the `opus` alias on the rpi commands.
- Bumped `rpi` plugin to `1.9.1` in `plugin.json` and `marketplace.json`.

## Why

Observed `rpi:thoughts-analyzer` skipping its own instructions ("Always enumerate first… `LS('./thoughts/')`") and only using `Read` with guessed filenames during a real research run. Older Sonnet models reliably degrade at this kind of structured-tool-use task. Letting agents float on the `sonnet` alias is the lowest-risk fix and matches existing convention for commands.

## Test plan

- [ ] Reinstall the plugin locally (`/plugin install rpi@claude-ruby-marketplace`) and confirm version reads `1.9.1`.
- [ ] Spawn `rpi:thoughts-analyzer` against a populated `thoughts/` tree and confirm it uses `LS`/`Glob`/`Grep` (not just `Read` with guessed paths).