### PR TITLE
fix(rpi): make subagent tools portable across Claude Code builds

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -59,7 +59,7 @@
     {
       "name": "rpi",
       "description": "RPI workflow: Research, Planning, Implementation with context engineering",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "source": "./plugins/rpi",
       "category": "workflow"
     }

--- a/plugins/rpi/.claude-plugin/plugin.json
+++ b/plugins/rpi/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rpi",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "RPI workflow: Research, Planning, Implementation. Context engineering system with structured agents and commands for AI-assisted development.",
   "author": {
     "name": "hoblin"

--- a/plugins/rpi/agents/codebase-analyzer.md
+++ b/plugins/rpi/agents/codebase-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: codebase-analyzer
 description: Analyzes codebase implementation details. Call the rpi:codebase-analyzer agent when you need to find detailed information about specific components. As always, the more detailed your request prompt, the better! :)
-tools: Read, Grep, Glob, LS
+tools: Read, Bash
 model: sonnet
 ---
 

--- a/plugins/rpi/agents/codebase-pattern-finder.md
+++ b/plugins/rpi/agents/codebase-pattern-finder.md
@@ -1,7 +1,7 @@
 ---
 name: codebase-pattern-finder
 description: rpi:codebase-pattern-finder is a useful subagent_type for finding similar implementations, usage examples, or existing patterns that can be modeled after. It will give you concrete code examples based on what you're looking for!
-tools: Grep, Glob, Read, LS
+tools: Read, Bash
 model: sonnet
 ---
 
@@ -47,7 +47,7 @@ What to look for based on request:
 - **Testing patterns**: How similar things are tested
 
 ### Step 2: Search!
-- You can use your handy dandy `Grep`, `Glob`, and `LS` tools to to find what you're looking for! You know how it's done!
+- Use `Bash` for filesystem search: `grep -rn 'pattern' path/`, `find path/ -name '*.rb'`, `ls path/`. You know how it's done!
 
 ### Step 3: Read and Extract
 - Read files with promising patterns

--- a/plugins/rpi/agents/documentation-researcher.md
+++ b/plugins/rpi/agents/documentation-researcher.md
@@ -1,7 +1,7 @@
 ---
 name: documentation-researcher
 description: Need to learn how to use a library, gem, or framework? This agent fetches up-to-date official documentation via Context7, understands your specific use case, and provides ready-to-use code examples. Great for setup guides, API usage, Rails methods, gem configuration, and implementation patterns.
-tools: mcp__context7__resolve-library-id, mcp__context7__get-library-docs, WebSearch, WebFetch, TodoWrite
+tools: mcp__context7__resolve-library-id, mcp__context7__get-library-docs, WebSearch, WebFetch, Read, Bash
 model: sonnet
 color: cyan
 ---

--- a/plugins/rpi/agents/thoughts-analyzer.md
+++ b/plugins/rpi/agents/thoughts-analyzer.md
@@ -32,17 +32,10 @@ You are a specialist at extracting HIGH-VALUE insights from thoughts documents. 
 
 ### Symlink-Aware Search
 
-Subdirectories in `./thoughts/` are typically symlinks (e.g. `./thoughts/shared/` points outside the repo). **Use uppercase `-R` for grep and `-L` for find — lowercase `-r` does NOT follow symlinks during traversal and will silently miss everything under those subdirs.**
+`./thoughts/shared/` and most subdirs are symlinks to paths outside the repo. Lowercase `grep -r` and bare `find` skip them silently — use uppercase **`-R`** and **`-L`**.
 
-Lead with one broad grep — it finds files that mention the term in frontmatter (`tags:`, `topic:`) AND in body text in a single pass:
-
-1. `Bash: grep -Rli 'VIB-1234' ./thoughts/` → list filenames containing the term (most valuable single command)
-2. `Bash: grep -Rni 'VIB-1234' ./thoughts/` → same with line numbers + matched text when you need context
-
-When you need to enumerate without a search term:
-
-3. `Bash: ls ./thoughts/` → discover top-level subdirs (shared/, username/, global/)
-4. `Bash: find -L ./thoughts/shared -type f -name '*.md'` → enumerate `.md` files following symlinks
+- `grep -Rli 'VIB-1234' ./thoughts/` — matches frontmatter (`tags:`, `topic:`) and body in one pass. Swap `-l` for `-n` to see matched lines.
+- `find -L ./thoughts/ -type f -name '*.md'` — enumerate when no search term applies.
 
 ### Step 1: Read with Purpose
 - Read the entire document first

--- a/plugins/rpi/agents/thoughts-analyzer.md
+++ b/plugins/rpi/agents/thoughts-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: thoughts-analyzer
 description: Extracts decisions and actionable insights from project history documents. Plans in thoughts/ contain problems, solutions, and reasoning - but mixed with exploration noise. Returns: what was decided, why, constraints identified, and whether conclusions are still valid. Filters noise, returns only high-value information.
-tools: Read, Grep, Glob, LS
+tools: Read, Bash
 model: sonnet
 ---
 
@@ -32,11 +32,11 @@ You are a specialist at extracting HIGH-VALUE insights from thoughts documents. 
 
 ### Symlink-Aware Search
 
-Subdirectories in `./thoughts/` are typically symlinks. Glob patterns like `./thoughts/**/*.md` skip symlinked directories.
+Subdirectories in `./thoughts/` are typically symlinks. Use `Bash` with `find -L` so symlinks are followed:
 
-**Always enumerate first, then search each directory explicitly:**
-1. `LS("./thoughts/")` → discover subdirs (shared/, username/, global/)
-2. `Glob("**/*.md", path="./thoughts/shared")` → search each explicitly
+1. `Bash: ls ./thoughts/` → discover subdirs (shared/, username/, global/)
+2. `Bash: find -L ./thoughts/shared -type f -name '*.md'` → enumerate files following symlinks
+3. `Bash: grep -rni 'pattern' ./thoughts/` → content search across symlinked subdirs
 
 ### Step 1: Read with Purpose
 - Read the entire document first

--- a/plugins/rpi/agents/thoughts-analyzer.md
+++ b/plugins/rpi/agents/thoughts-analyzer.md
@@ -32,11 +32,17 @@ You are a specialist at extracting HIGH-VALUE insights from thoughts documents. 
 
 ### Symlink-Aware Search
 
-Subdirectories in `./thoughts/` are typically symlinks. Use `Bash` with `find -L` so symlinks are followed:
+Subdirectories in `./thoughts/` are typically symlinks (e.g. `./thoughts/shared/` points outside the repo). **Use uppercase `-R` for grep and `-L` for find — lowercase `-r` does NOT follow symlinks during traversal and will silently miss everything under those subdirs.**
 
-1. `Bash: ls ./thoughts/` → discover subdirs (shared/, username/, global/)
-2. `Bash: find -L ./thoughts/shared -type f -name '*.md'` → enumerate files following symlinks
-3. `Bash: grep -rni 'pattern' ./thoughts/` → content search across symlinked subdirs
+Lead with one broad grep — it finds files that mention the term in frontmatter (`tags:`, `topic:`) AND in body text in a single pass:
+
+1. `Bash: grep -Rli 'VIB-1234' ./thoughts/` → list filenames containing the term (most valuable single command)
+2. `Bash: grep -Rni 'VIB-1234' ./thoughts/` → same with line numbers + matched text when you need context
+
+When you need to enumerate without a search term:
+
+3. `Bash: ls ./thoughts/` → discover top-level subdirs (shared/, username/, global/)
+4. `Bash: find -L ./thoughts/shared -type f -name '*.md'` → enumerate `.md` files following symlinks
 
 ### Step 1: Read with Purpose
 - Read the entire document first

--- a/plugins/rpi/agents/web-search-researcher.md
+++ b/plugins/rpi/agents/web-search-researcher.md
@@ -1,7 +1,7 @@
 ---
 name: web-search-researcher
 description: Do you find yourself desiring information that you don't quite feel well-trained (confident) on? Information that is modern and potentially only discoverable on the web? Use the rpi:web-search-researcher subagent_type today to find any and all answers to your questions! It will research deeply to figure out and attempt to answer your questions! If you aren't immediately satisfied you can get your money back! (Not really - but you can re-run rpi:web-search-researcher with an altered prompt in the event you're not satisfied the first time)
-tools: WebSearch, WebFetch, TodoWrite, Read, Grep, Glob, LS
+tools: WebSearch, WebFetch
 color: yellow
 model: sonnet
 maxTurns: 25


### PR DESCRIPTION
## Problem

Claude Code builds compiled with `EMBEDDED_SEARCH_TOOLS=1` (e.g. the ant-native bun-bundled builds) remove the dedicated `Glob`, `Grep`, and `LS` tools from the runtime registry — `find`/`grep` are shimmed into Bash via embedded `bfs`/`ugrep` instead. The subagent loader (`tools/AgentTool/agentToolUtils.ts:resolveAgentTools`) intersects each agent's declared `tools:` list against the live registry and **silently drops** unknown names into an `invalidTools` array that is never surfaced at spawn time.

Result: every `rpi/*` analyzer that declared `tools: Read, Grep, Glob, LS` ended up with **only `Read`** at runtime. Calling `Read` on a directory returns `EISDIR`, so the agents got stuck in loops walking `thoughts/` or codebase trees and produced no real output. Newer builds also dropped `TodoWrite` (replaced by `TaskCreate`/`TaskUpdate`/etc.), silently breaking the researcher agents the same way.

## Fix

Rewrite each agent's `tools:` list to use names that exist in every modern build, and update the system prompts so they steer the agent to the right invocations.

| Agent | Before | After |
|---|---|---|
| `thoughts-analyzer` | `Read, Grep, Glob, LS` | `Read, Bash` |
| `codebase-analyzer` | `Read, Grep, Glob, LS` | `Read, Bash` |
| `codebase-pattern-finder` | `Grep, Glob, Read, LS` | `Read, Bash` |
| `web-search-researcher` | `WebSearch, WebFetch, TodoWrite, Read, Grep, Glob, LS` | `WebSearch, WebFetch` |
| `documentation-researcher` | `mcp__context7__*, WebSearch, WebFetch, TodoWrite` | `mcp__context7__*, WebSearch, WebFetch, Read, Bash` |

`web-search-researcher` is trimmed to its actual surface — its body never used the local-search tools.

System prompt updates:
- `thoughts-analyzer`: rewrite the symlink-aware search section from `LS("./thoughts/")` / `Glob("**/*.md")` to `Bash: ls`, `Bash: find -L`, `Bash: grep -rni`.
- `codebase-pattern-finder`: rewrite the "use Grep/Glob/LS" instruction to `Bash: grep -rn`, `find -name`, `ls`.

## Verification

Before — spawning `rpi:thoughts-analyzer` produced an `EISDIR`-fueled loop of `Read(...)` calls on directories and zero useful output.

After — with `tools: Read, Bash`, the agent successfully:
- `Read` on a unique marker file → returns the actual marker contents
- `Bash` `cat ... && echo pid=$$` → returns the marker plus a real subprocess PID
- Refuses calls to `Grep` with a clean "tool not available" error (no fabrication)

`tool_uses: 2` on the verification probe confirms real invocation, not hallucination.

## Compatibility

The new tool sets work on **both** ant-native (`EMBEDDED_SEARCH_TOOLS=1`) and standard Claude Code builds, since `Read`, `Bash`, `WebSearch`, `WebFetch`, and the `mcp__context7__*` tools are universal.

## Versioning

Patch bump: `rpi` 1.9.1 → 1.9.2 in both `plugins/rpi/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`.

## Test plan

- [ ] `/plugin update rpi` from this branch
- [ ] Restart a Claude Code session
- [ ] Spawn each `rpi:*` agent with a real task and confirm tool_uses > 0 and no EISDIR loops
- [ ] Standard Claude Code build (without `EMBEDDED_SEARCH_TOOLS=1`) — confirm Bash-based search still produces equivalent results