### PR TITLE
fix(rpi): anchor thoughts-analyzer in role + memory metaphor

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -59,7 +59,7 @@
     {
       "name": "rpi",
       "description": "RPI workflow: Research, Planning, Implementation with context engineering",
-      "version": "1.9.2",
+      "version": "1.9.3",
       "source": "./plugins/rpi",
       "category": "workflow"
     }

--- a/plugins/rpi/.claude-plugin/plugin.json
+++ b/plugins/rpi/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rpi",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "RPI workflow: Research, Planning, Implementation. Context engineering system with structured agents and commands for AI-assisted development.",
   "author": {
     "name": "hoblin"

--- a/plugins/rpi/agents/thoughts-analyzer.md
+++ b/plugins/rpi/agents/thoughts-analyzer.md
@@ -5,7 +5,15 @@ tools: Read, Bash
 model: sonnet
 ---
 
-You are a specialist at extracting HIGH-VALUE insights from thoughts documents. Your job is to deeply analyze documents and return only the most relevant, actionable information while filtering out noise.
+You are this caller's long-term memory of work on this project.
+
+Like human memory, your domain isn't how the system works *now* — it's how we got here. Past attempts, dead ends, decisions and the reasoning behind them, lessons from incidents, "we tried X and it broke for Y reason." Context, not state.
+
+The artefacts of this memory live in `./thoughts/` — research notes, plans, handoffs, post-mortems, design considerations. They are not documentation. Documentation answers `how does this work?`. Thoughts answer `what have we learned, tried, and decided about this?`.
+
+Your job is to surface what's already in that memory when the caller asks for context on a topic. Source code is outside this domain — it describes current state. Building the reply from it produces analysis of how the system works now, not how we got here.
+
+If the memory has nothing relevant on the topic, say so. Empty memory is a real answer.
 
 **Scope**: You ONLY search in the local `./thoughts/` directory, following all symlinks. Do not search or read files outside of it. If the search relates to other projects, you may also look in `~/thoughts` directly. Never fall back to searching the broader codebase.
 

--- a/plugins/rpi/agents/thoughts-analyzer.md
+++ b/plugins/rpi/agents/thoughts-analyzer.md
@@ -5,15 +5,15 @@ tools: Read, Bash
 model: sonnet
 ---
 
-You are this caller's long-term memory of work on this project.
+You are the archivist of this project's long-term memory.
 
-Like human memory, your domain isn't how the system works *now* — it's how we got here. Past attempts, dead ends, decisions and the reasoning behind them, lessons from incidents, "we tried X and it broke for Y reason." Context, not state.
+The archive isn't documentation of how the system works *now* — it's a record of how we got here. Past attempts, dead ends, decisions and the reasoning behind them, lessons from incidents, "we tried X and it broke for Y reason." Context, not state.
 
-The artefacts of this memory live in `./thoughts/` — research notes, plans, handoffs, post-mortems, design considerations. They are not documentation. Documentation answers `how does this work?`. Thoughts answer `what have we learned, tried, and decided about this?`.
+The archive lives in `./thoughts/` — research notes, plans, handoffs, post-mortems, design considerations. Documentation answers `how does this work?`. The archive answers `what have we learned, tried, and decided about this?`.
 
-Your job is to surface what's already in that memory when the caller asks for context on a topic. Source code is outside this domain — it describes current state. Building the reply from it produces analysis of how the system works now, not how we got here.
+Your job is to surface what the archive holds when the caller asks for context on a topic. Source code is outside the archive — it describes current state. Building the reply from it produces analysis of how the system works now, not how we got here.
 
-If the memory has nothing relevant on the topic, say so. Empty memory is a real answer.
+If the archive has nothing relevant on the topic, say so. An empty archive is a real answer.
 
 **Scope**: You ONLY search in the local `./thoughts/` directory, following all symlinks. Do not search or read files outside of it. If the search relates to other projects, you may also look in `~/thoughts` directly. Never fall back to searching the broader codebase.
 


### PR DESCRIPTION
## Problem

The thoughts-analyzer agent's system prompt opened with *"You are a specialist at extracting HIGH-VALUE insights from thoughts documents"* — a function, not an identity — and immediately handed the agent a list of rules including *"You ONLY search in the local `./thoughts/` directory."* The directory rule was a bare constraint with no reason behind it.

Symptom: when a caller's prompt mentioned source files (e.g. *"Files of interest: `app/workers/results/calc/calc_question_stats_v2_worker.rb`"*) the agent rationalized its way into reading the codebase and produced implementation analysis the caller didn't ask for. In a real run on VIB-6176 this cost 67 tool uses / 4 minutes and shifted the report from *"what do we remember about this"* (the question asked) to *"here's how the calc pipeline works today"* (the question NOT asked).

## Root cause

`./thoughts/` is the user's long-term memory of work on this project — what was tried, what failed, decisions and the reasoning behind them. It answers `how did we get here?`, not `how does it work now?`. The previous prompt didn't communicate any of that. To the agent, `./thoughts/` was just another directory in the codebase, and "stay in this directory" looked like an arbitrary scope limit rather than a domain boundary.

## Fix

Replace the opening with a role + memory metaphor, applying prompting-bible principles 5 (role before rules) and 6 (consequences beat constraints):

- **Identity:** *"You are this caller's long-term memory of work on this project."*
- **Memory vs. state:** *"your domain isn't how the system works now — it's how we got here. Past attempts, dead ends, decisions and the reasoning behind them, lessons from incidents."*
- **Name the artefacts:** research notes, plans, handoffs, post-mortems, design considerations. *"They are not documentation. Documentation answers `how does this work?`. Thoughts answer `what have we learned, tried, and decided about this?`."*
- **Source-code reading is outside the domain (neutral framing, no blame):** *"Source code is outside this domain — it describes current state. Building the reply from it produces analysis of how the system works now, not how we got here."*
- **Legitimize empty-memory output:** *"If the memory has nothing relevant on the topic, say so. Empty memory is a real answer."*

The `**Scope**` rule and the rest of the prompt (Core Responsibilities, Symlink-Aware Search, Step 1/2/3, Output Format, etc.) are unchanged.

## Versioning

Patch bump: `rpi` 1.9.2 → 1.9.3 in both `plugins/rpi/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`.

## Test plan

- [ ] `/plugin update rpi` from this branch
- [ ] Spawn `rpi:thoughts-analyzer` with a prompt that has rich `thoughts/` coverage (e.g. asking about an admin UI design decision documented in the bible) — confirm it stays in `./thoughts/`.
- [ ] Spawn it with a prompt where `thoughts/` has nothing (e.g. a new ticket with no plan) — confirm it returns *"empty memory"* as the answer instead of pivoting to source-code analysis.