### PR TITLE
fix(rpi): pull thoughts before searching in thoughts-analyzer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -59,7 +59,7 @@
     {
       "name": "rpi",
       "description": "RPI workflow: Research, Planning, Implementation with context engineering",
-      "version": "1.9.4",
+      "version": "1.9.5",
       "source": "./plugins/rpi",
       "category": "workflow"
     }

--- a/plugins/rpi/.claude-plugin/plugin.json
+++ b/plugins/rpi/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rpi",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "RPI workflow: Research, Planning, Implementation. Context engineering system with structured agents and commands for AI-assisted development.",
   "author": {
     "name": "hoblin"

--- a/plugins/rpi/agents/thoughts-analyzer.md
+++ b/plugins/rpi/agents/thoughts-analyzer.md
@@ -38,6 +38,12 @@ If the archive has nothing relevant on the topic, say so. An empty archive is a 
 
 ## Analysis Strategy
 
+### Step 0: Pull Fresh Archive
+
+The archive is a shared git repo — teammates push notes, plans, and handoffs you may not have locally yet. **Before searching, run `thoughts-sync`** to commit any local changes, pull the latest from the team, and push back. Skipping this step silently misses recent team work and produces false "not found" answers.
+
+If `thoughts-sync` fails (no PATH, conflicts, no remote), report the failure to the caller and continue with the local snapshot — note the limitation in your final answer.
+
 ### Symlink-Aware Search
 
 `./thoughts/shared/` and most subdirs are symlinks to paths outside the repo. Lowercase `grep -r` and bare `find` skip them silently — use uppercase **`-R`** and **`-L`**.

--- a/plugins/rpi/agents/thoughts-analyzer.md
+++ b/plugins/rpi/agents/thoughts-analyzer.md
@@ -17,6 +17,12 @@ If the archive has nothing relevant on the topic, say so. An empty archive is a 
 
 **Scope**: You ONLY search in the local `./thoughts/` directory, following all symlinks. Do not search or read files outside of it. If the search relates to other projects, you may also look in `~/thoughts` directly. Never fall back to searching the broader codebase.
 
+## First: Sync the Archive
+
+The archive is a shared git repo — teammates push notes, plans, and handoffs you may not have locally yet. **Before any search or read, run `thoughts-sync` once** to commit local changes, pull the latest from the team, and push back. Skipping this step silently misses recent team work and produces false "not found" answers.
+
+If `thoughts-sync` fails (not on PATH, merge conflict, no remote), report the failure to the caller and continue with the local snapshot — note the limitation in your final answer.
+
 ## Core Responsibilities
 
 1. **Extract Key Insights**
@@ -37,12 +43,6 @@ If the archive has nothing relevant on the topic, say so. An empty archive is a 
    - Distinguish decisions from explorations
 
 ## Analysis Strategy
-
-### Step 0: Pull Fresh Archive
-
-The archive is a shared git repo — teammates push notes, plans, and handoffs you may not have locally yet. **Before searching, run `thoughts-sync`** to commit any local changes, pull the latest from the team, and push back. Skipping this step silently misses recent team work and produces false "not found" answers.
-
-If `thoughts-sync` fails (no PATH, conflicts, no remote), report the failure to the caller and continue with the local snapshot — note the limitation in your final answer.
 
 ### Symlink-Aware Search
 


### PR DESCRIPTION
## Summary

- The thoughts archive at `~/thoughts/` is a shared git repo. Consumers (e.g. `/rpi:review-pr`, `/rpi:feature`) that spawn `rpi:thoughts-analyzer` against a local checkout that's behind the team would miss teammates' recent notes/plans and report them as **"not found"** — producing false gaps in reviews and plans.
  - Real-world case: [vibemetrics/vibemetrics-api#5611](https://github.com/vibemetrics/vibemetrics-api/pull/5611) review claimed a referenced ADR didn't exist on disk; it existed in the team archive, just not on the reviewer's local checkout.
- Fix: add **Step 0: Pull Fresh Archive** to `rpi:thoughts-analyzer` so every consumer command pulls before searching. Single sync point covers `/rpi:feature`, `/rpi:review-pr`, `/rpi:create_plan`, `/rpi:iterate_plan`, `/rpi:research_codebase`.
- Bumps `rpi` plugin to **1.9.5** (patch — behavior fix, no API change).

## Known gap (not addressed here)

`/rpi:implement_plan` and `/rpi:validate_plan` read `./thoughts/shared/plans/…` by direct path without invoking the analyzer, so they still won't auto-sync. Left as a follow-up — most users running those commands have just produced or iterated the plan, so the local checkout is already fresh in practice.

## Test plan

- [x] Verified terse "Run \`thoughts-sync\`" instruction is interpreted correctly by a sonnet subagent (1 Bash call, no \`which\` probing) — no wording change needed beyond Step 0.
- [ ] Manual: install locally, run `/rpi:review-pr` against a PR whose author referenced a thoughts doc that the reviewer hasn't pulled yet; confirm the doc is found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)