### PR TITLE
#36 feat: feature workflow self-reviews once CI is green

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -59,7 +59,7 @@
     {
       "name": "rpi",
       "description": "RPI workflow: Research, Planning, Implementation with context engineering",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "source": "./plugins/rpi",
       "category": "workflow"
     }

--- a/plugins/rpi/.claude-plugin/plugin.json
+++ b/plugins/rpi/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rpi",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "RPI workflow: Research, Planning, Implementation. Context engineering system with structured agents and commands for AI-assisted development.",
   "author": {
     "name": "hoblin"

--- a/plugins/rpi/README.md
+++ b/plugins/rpi/README.md
@@ -221,6 +221,7 @@ These agents are spawned in parallel by `/rpi:review-pr`, which picks the roster
 - Researches codebase via parallel `rpi:codebase-pattern-finder` and `rpi:codebase-analyzer`
 - Implements feature following Rails best practices
 - Runs QA checks and creates draft PR
+- Self-reviews automatically once CI is green (`/rpi:review-pr` self-review) and marks the PR ready
 - For smaller features that don't need multi-session planning
 
 **`/rpi:review-pr`** - Multi-agent PR review with four modes

--- a/plugins/rpi/commands/feature.md
+++ b/plugins/rpi/commands/feature.md
@@ -83,7 +83,7 @@ When all checks are green, proceed to "Step 9: Self-Review & Finalization". If t
 
 ### Step 9: Self-Review & Finalization
 
-Run the `/rpi:review-pr` command in `self-review` mode on the PR, passing through any additional instructions from user input. It fans out the review subagents, fixes accepted findings, pushes, waits for CI again, and marks the PR ready with the user assigned — the pipeline isn't done at green, it's done at ready.
+Run the `/rpi:review-pr` command in `self-review` mode on the PR, passing through any additional instructions from user input — the pipeline isn't done at green, it's done at ready.
 Update PR title/description if needed.
 
 ## Requirements

--- a/plugins/rpi/commands/feature.md
+++ b/plugins/rpi/commands/feature.md
@@ -79,9 +79,11 @@ Description: summary, test plan, breaking changes. Link to the issue.
 Monitor checks until all pass.
 If tests fail, investigate root cause vs flakiness.
 Fix flaky tests – don't just retry; stabilize the test.
+When all checks are green, proceed to "Step 9: Self-Review & Finalization". If the repo has no CI, proceed there directly after Step 7.
 
-### Step 9: Finalization
+### Step 9: Self-Review & Finalization
 
+Run the `/rpi:review-pr` command in `self-review` mode on the PR, passing through any additional instructions from user input. It fans out the review subagents, fixes accepted findings, pushes, waits for CI again, and marks the PR ready with the user assigned — the pipeline isn't done at green, it's done at ready.
 Update PR title/description if needed.
 
 ## Requirements


### PR DESCRIPTION
Closes #36.

## Summary

- `feature.md` Step 8 now bridges to a renamed "Step 9: Self-Review & Finalization" on green CI (explicit step-name bridge, per the orchestrator-prompt lessons); repos without CI route there directly after Step 7.
- Step 9 runs `/rpi:review-pr` in self-review mode — referenced, not duplicated — passing the original invocation's additional instructions through. The pipeline isn't done at green, it's done at ready.
- README bullet added; rpi 1.10.0 → 1.11.0 in both manifests.

## Out of scope (per #36)

Auto `address-feedback` on bot comments — per-repo trigger territory.

## Test plan

Prose-only change to the workflow command; live validation is the next `/rpi:feature` run reaching green CI and continuing into self-review unprompted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)