### PR TITLE
feat(rpi): harden reviewer principles from first live run

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -59,7 +59,7 @@
     {
       "name": "rpi",
       "description": "RPI workflow: Research, Planning, Implementation with context engineering",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "source": "./plugins/rpi",
       "category": "workflow"
     }

--- a/plugins/rpi/.claude-plugin/plugin.json
+++ b/plugins/rpi/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rpi",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "RPI workflow: Research, Planning, Implementation. Context engineering system with structured agents and commands for AI-assisted development.",
   "author": {
     "name": "hoblin"

--- a/plugins/rpi/agents/review-docs.md
+++ b/plugins/rpi/agents/review-docs.md
@@ -17,6 +17,14 @@ Read every changed file fully — not grep/sed excerpts — so you understand th
 
 Empirically the main flaw in AI-generated code: comments that narrate the author's reasoning process, development history, or review dialogue instead of stating a constraint the code cannot show. "Simplified per review feedback", "this now uses the new API" — these document the session, not the system, and they rot the moment the PR merges. Hunt them; durable documentation describes what is, not how it came to be.
 
+### Tests document themselves
+
+The test DSL is the documentation layer: `context > describe > it` in RSpec, test names and assertion messages in minitest. A comment inside a test body signals intent that didn't fit the structure. Report it, pointing to where the information belongs: the description, a better assertion message, or the commit.
+
+### Precedent is not authority
+
+A precedent does not legitimize an antipattern — it locates another instance of it. When "a sibling does the same" tempts you to accept, first ask whether the sibling is itself a finding worth reporting.
+
 ### Self-refute before reporting
 
 Before emitting any finding or pass, try to refute it. Before calling a comment outdated, prove the code moved.

--- a/plugins/rpi/agents/review-generic.md
+++ b/plugins/rpi/agents/review-generic.md
@@ -21,6 +21,10 @@ For each addition ask "should this exist — is there a smaller, idiomatic form 
 
 Code comments and the PR description are claims to verify against the code and the ticket, never facts.
 
+### Precedent is not authority
+
+A precedent does not legitimize an antipattern — it locates another instance of it. When "a sibling does the same" tempts you to accept, first ask whether the sibling is itself a finding worth reporting.
+
 ### Self-refute before reporting
 
 Before emitting any finding or pass, try to refute it. For "matches existing pattern X" claims, open X and prove it.

--- a/plugins/rpi/agents/review-performance.md
+++ b/plugins/rpi/agents/review-performance.md
@@ -24,6 +24,10 @@ For each addition ask "should this exist — is there a smaller, framework-nativ
 
 Code comments and the PR description are claims to verify against the code and the ticket, never facts.
 
+### Precedent is not authority
+
+A precedent does not legitimize an antipattern — it locates another instance of it. When "a sibling does the same" tempts you to accept, first ask whether the sibling is itself a finding worth reporting.
+
 ### Self-refute before reporting
 
 Before emitting any finding or pass, try to refute it. Prove an N+1 by tracing the association, not by pattern-matching the loop.

--- a/plugins/rpi/agents/review-tests-minitest.md
+++ b/plugins/rpi/agents/review-tests-minitest.md
@@ -29,6 +29,10 @@ Ask what the ticket's behavior demands be tested, not only whether the written t
 
 Test names and the PR description are claims to verify against the assertions, never facts. A `test "handles the edge case"` block proves nothing until you read its assertions.
 
+### Precedent is not authority
+
+A precedent does not legitimize an antipattern — it locates another instance of it. When "a sibling does the same" tempts you to accept, first ask whether the sibling is itself a finding worth reporting.
+
 ### Self-refute before reporting
 
 Before emitting any finding or pass, try to refute it. Before accepting coverage as sufficient, name the edge case that would break it.

--- a/plugins/rpi/agents/review-tests-rspec.md
+++ b/plugins/rpi/agents/review-tests-rspec.md
@@ -23,6 +23,10 @@ Ask what the ticket's behavior demands be tested, not only whether the written s
 
 Spec descriptions and the PR description are claims to verify against the assertions, never facts. An `it "handles the edge case"` block proves nothing until you read its expectations.
 
+### Precedent is not authority
+
+A precedent does not legitimize an antipattern — it locates another instance of it. When "a sibling does the same" tempts you to accept, first ask whether the sibling is itself a finding worth reporting.
+
 ### Self-refute before reporting
 
 Before emitting any finding or pass, try to refute it. Before accepting coverage as sufficient, name the edge case that would break it.

--- a/plugins/rpi/agents/review-ticket-delivery.md
+++ b/plugins/rpi/agents/review-ticket-delivery.md
@@ -19,6 +19,10 @@ Read every changed file fully — not grep/sed excerpts — when mapping a requi
 
 Code comments and the PR description are claims to verify against the code and the ticket, never facts.
 
+### Precedent is not authority
+
+A precedent does not legitimize an antipattern — it locates another instance of it. When "a sibling does the same" tempts you to accept, first ask whether the sibling is itself a finding worth reporting.
+
 ### Self-refute before reporting
 
 Before marking any requirement ✅ delivered, try to refute it against the ticket's verbs.

--- a/plugins/rpi/commands/review-pr.md
+++ b/plugins/rpi/commands/review-pr.md
@@ -102,7 +102,7 @@ subagent_type: rpi:thoughts-analyzer
 Prompt: "What do we know about <ticket reference and title from "Step 3: Fetch Original Ticket">? What decisions, constraints, and trade-offs should reviewers be aware of?"
 ```
 
-The harness saves the subagent's report to a task output file and shows the path when it completes — note that path. It is the historical-context artifact you pass to reviewers. Never retype or re-summarize the report into a new file: retyping burns tokens, and a re-summary is exactly where your conclusions leak in.
+The harness saves the subagent's report to a task output file and shows the path when it completes — note that path. It is the historical-context artifact you pass to reviewers. If no path was surfaced (the report came back inline), save it verbatim to `/tmp/pr_<NUMBER>_context.md` yourself. Either way the artifact is a copy, never a rewrite: a re-summary is exactly where your conclusions leak in.
 
 **Wait for this subagent to complete, then proceed to "Step 5-a: Spawn Review Subagents".**
 
@@ -173,6 +173,7 @@ For each concern, evaluate:
 - **Cost-benefit** — Does the fix add more complexity than the problem warrants? If the "fix" makes the code harder to read without solving a problem a human would encounter, drop it.
 - **Scope** — Review fixes should improve code you're touching, not introduce new artifacts. Clean up, don't build out.
 - **Design intent** — Was this a deliberate choice? A concern that flags a conscious trade-off documented in historical context is a decline, not a fix.
+- **Precedent** — "Existing code does the same" declines nothing on its own: a precedent does not legitimize an antipattern, it locates another instance of it. Legitimacy comes from documented standards, not recurrence.
 
 Then classify:
 - **Accept & fix** — concern valid, apply the suggested fix or a better one


### PR DESCRIPTION
## Summary

Three refinements to the 1.10.0 static reviewers (#34/#35), all sourced from their first live run — a real multi-round review session on a Rails PR (untouched-form role-visibility fix), which doubled as the regression check #34 left unchecked.

- **Precedent is not authority** — new principle in all six reviewers that lacked it (review-rails already carried it inside *Compare against siblings*), plus a fifth judgment criterion in Step 6: *"Existing code does the same" declines nothing on its own — a precedent does not legitimize an antipattern, it locates another instance of it.*
- **Tests document themselves** (review-docs) — the test DSL is the documentation layer (`context > describe > it`, test names, assertion messages); a comment inside a test body signals intent that didn't fit the structure. Report it with where the information belongs.
- **Step 4 artifact fallback** — when the thoughts-analyzer report comes back inline with no task output path, the orchestrator saves it verbatim (copy, never rewrite).

## Evidence from the live run

1. A 4-line narration comment landed in a regression test; **review-docs read it and approved**, citing sibling comments in the same file — while **review-ticket-delivery** (out of domain) correctly called it narration. The correct finding then **died at the merge step**: the orchestrator declined it citing the same in-file precedent. Same reflex, three layers — author, in-domain reviewer, judge. The precedent principle targets all three; the test-comment principle makes the in-domain reviewer catch it first.
2. The Step 4 contract ("the harness shows the path — note it") didn't hold for synchronous spawns: the report arrived inline twice, forcing an undocumented improvisation the fallback line now sanctions.

rpi `1.11.0 → 1.11.1` in both manifests (prompt-content refinement, no structural change).

## Test plan

- Sanitization grep for org-specific strings across touched files: clean.
- Principles placement mirrors existing section order (before *Self-refute*); wording follows prompting-bible rule 4 (mechanism over prohibition).
- Live re-run against a real PR is the true test — next `/rpi:review-pr` session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

