### PR TITLE
feat(rpi): Approve & merge option in review-pr

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -59,7 +59,7 @@
     {
       "name": "rpi",
       "description": "RPI workflow: Research, Planning, Implementation with context engineering",
-      "version": "1.11.1",
+      "version": "1.12.0",
       "source": "./plugins/rpi",
       "category": "workflow"
     }

--- a/plugins/rpi/.claude-plugin/plugin.json
+++ b/plugins/rpi/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rpi",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "RPI workflow: Research, Planning, Implementation. Context engineering system with structured agents and commands for AI-assisted development.",
   "author": {
     "name": "hoblin"

--- a/plugins/rpi/commands/review-pr.md
+++ b/plugins/rpi/commands/review-pr.md
@@ -205,6 +205,9 @@ Use the AskUserQuestion tool to confirm: "Shall I post this review to the PR? [Y
 - **Edit** — let the user modify the review, then ask again
 - **Cancel** — discard
 
+If the verdict is APPROVE and nothing in the gathered artifacts blocks delivery (no "don't merge until…" notes, dependent PRs, or coordinated-deploy requirements in the ticket, reviews, or findings), include a fourth option: **Approve & merge**.
+- **Approve & merge** — post the approving review, then monitor `gh pr checks <PR_NUMBER> --watch`; when green, merge using the repository's convention (e.g. squash). If CI fails, stop and report — never merge red.
+
 Once confirmed, post the review:
 
 ```bash

--- a/plugins/rpi/commands/review-pr.md
+++ b/plugins/rpi/commands/review-pr.md
@@ -193,12 +193,14 @@ Determine verdict:
 
 ### Step 7: Present Review (review / re-review)
 
-If self-review or address-feedback mode is activated, skip to "Step 8: Apply Fixes".
+If self-review or address-feedback mode is activated, skip to "Step 9: Apply Fixes".
 
 Present the merged review to the user, including:
 - PR reference and ticket (if found)
 - Determined verdict
 - All findings grouped by severity
+
+### Step 8: Confirm and Post (review / re-review)
 
 Use the AskUserQuestion tool to confirm: "Shall I post this review to the PR? [Yes/Edit/Cancel]"
 - **Yes** — post the review
@@ -216,7 +218,7 @@ gh pr review <PR_NUMBER> --approve --body "<review body>"
 gh pr review <PR_NUMBER> --request-changes --body "<review body>"
 ```
 
-### Step 8: Apply Fixes (self-review / address-feedback)
+### Step 9: Apply Fixes (self-review / address-feedback)
 
 Your role changes from orchestrator to doer. You now have the judgment results — act on them.
 


### PR DESCRIPTION
## Summary

When the merged verdict is APPROVE and the gathered artifacts show no delivery blockers (no "don't merge until…" notes, dependent PRs, or coordinated-deploy requirements), Step 7's confirmation offers a fourth option — **Approve & merge**: post the approving review, monitor `gh pr checks --watch`, merge with the repository's convention when green. Failing CI stops the merge.

Bumps rpi to 1.12.0 (plugin.json + marketplace.json synced).