### PR TITLE
feat(rpi): make re-review a converging confirmation round

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -59,7 +59,7 @@
     {
       "name": "rpi",
       "description": "RPI workflow: Research, Planning, Implementation with context engineering",
-      "version": "1.13.0",
+      "version": "1.12.1",
       "source": "./plugins/rpi",
       "category": "workflow"
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -59,7 +59,7 @@
     {
       "name": "rpi",
       "description": "RPI workflow: Research, Planning, Implementation with context engineering",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "source": "./plugins/rpi",
       "category": "workflow"
     }

--- a/plugins/rpi/.claude-plugin/plugin.json
+++ b/plugins/rpi/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rpi",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "RPI workflow: Research, Planning, Implementation. Context engineering system with structured agents and commands for AI-assisted development.",
   "author": {
     "name": "hoblin"

--- a/plugins/rpi/.claude-plugin/plugin.json
+++ b/plugins/rpi/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rpi",
-  "version": "1.13.0",
+  "version": "1.12.1",
   "description": "RPI workflow: Research, Planning, Implementation. Context engineering system with structured agents and commands for AI-assisted development.",
   "author": {
     "name": "hoblin"

--- a/plugins/rpi/agents/review-docs.md
+++ b/plugins/rpi/agents/review-docs.md
@@ -41,7 +41,7 @@ Before emitting any finding or pass, try to refute it. Before calling a comment 
 
 ### Prior feedback
 
-If you received paths to prior review feedback (reviews, inline comments, conversation), your main focus shifts: first verify the previously requested changes were addressed, and only then check for new problems introduced.
+If you received paths to prior review feedback (reviews, inline comments, conversation), it is a re-review: verify each previously requested change was addressed, and check that no new problems were introduced. Review at full scope and report what you find at honest severity — but understand the round's purpose: it exists to close the review, not restart it. A new [major] must surface; smaller new findings are input for the judge, not grounds to reopen on their own.
 
 ## Output
 

--- a/plugins/rpi/agents/review-generic.md
+++ b/plugins/rpi/agents/review-generic.md
@@ -35,7 +35,7 @@ The orchestrator passes your domain and focus list — scope, not conclusions: i
 
 ### Prior feedback
 
-If you received paths to prior review feedback (reviews, inline comments, conversation), your main focus shifts: first verify the previously requested changes were addressed, and only then check for new problems introduced.
+If you received paths to prior review feedback (reviews, inline comments, conversation), it is a re-review: verify each previously requested change was addressed, and check that no new problems were introduced. Review at full scope and report what you find at honest severity — but understand the round's purpose: it exists to close the review, not restart it. A new [major] must surface; smaller new findings are input for the judge, not grounds to reopen on their own.
 
 ## Output
 

--- a/plugins/rpi/agents/review-performance.md
+++ b/plugins/rpi/agents/review-performance.md
@@ -46,7 +46,7 @@ Before emitting any finding or pass, try to refute it. Prove an N+1 by tracing t
 
 ### Prior feedback
 
-If you received paths to prior review feedback (reviews, inline comments, conversation), your main focus shifts: first verify the previously requested changes were addressed, and only then check for new problems introduced.
+If you received paths to prior review feedback (reviews, inline comments, conversation), it is a re-review: verify each previously requested change was addressed, and check that no new problems were introduced. Review at full scope and report what you find at honest severity — but understand the round's purpose: it exists to close the review, not restart it. A new [major] must surface; smaller new findings are input for the judge, not grounds to reopen on their own.
 
 ## Output
 

--- a/plugins/rpi/agents/review-rails.md
+++ b/plugins/rpi/agents/review-rails.md
@@ -47,7 +47,7 @@ Before emitting any finding or pass, try to refute it. For "matches sibling X" c
 
 ### Prior feedback
 
-If you received paths to prior review feedback (reviews, inline comments, conversation), your main focus shifts: first verify the previously requested changes were addressed, and only then check for new problems introduced.
+If you received paths to prior review feedback (reviews, inline comments, conversation), it is a re-review: verify each previously requested change was addressed, and check that no new problems were introduced. Review at full scope and report what you find at honest severity — but understand the round's purpose: it exists to close the review, not restart it. A new [major] must surface; smaller new findings are input for the judge, not grounds to reopen on their own.
 
 ## Output
 

--- a/plugins/rpi/agents/review-tests-minitest.md
+++ b/plugins/rpi/agents/review-tests-minitest.md
@@ -51,7 +51,7 @@ Before emitting any finding or pass, try to refute it. Before accepting coverage
 
 ### Prior feedback
 
-If you received paths to prior review feedback (reviews, inline comments, conversation), your main focus shifts: first verify the previously requested changes were addressed, and only then check for new problems introduced.
+If you received paths to prior review feedback (reviews, inline comments, conversation), it is a re-review: verify each previously requested change was addressed, and check that no new problems were introduced. Review at full scope and report what you find at honest severity — but understand the round's purpose: it exists to close the review, not restart it. A new [major] must surface; smaller new findings are input for the judge, not grounds to reopen on their own.
 
 ## Output
 

--- a/plugins/rpi/agents/review-tests-rspec.md
+++ b/plugins/rpi/agents/review-tests-rspec.md
@@ -45,7 +45,7 @@ Before emitting any finding or pass, try to refute it. Before accepting coverage
 
 ### Prior feedback
 
-If you received paths to prior review feedback (reviews, inline comments, conversation), your main focus shifts: first verify the previously requested changes were addressed, and only then check for new problems introduced.
+If you received paths to prior review feedback (reviews, inline comments, conversation), it is a re-review: verify each previously requested change was addressed, and check that no new problems were introduced. Review at full scope and report what you find at honest severity — but understand the round's purpose: it exists to close the review, not restart it. A new [major] must surface; smaller new findings are input for the judge, not grounds to reopen on their own.
 
 ## Output
 

--- a/plugins/rpi/agents/review-ticket-delivery.md
+++ b/plugins/rpi/agents/review-ticket-delivery.md
@@ -41,7 +41,7 @@ There is no dedicated security reviewer, and you are the one reviewer that runs 
 
 ### Prior feedback
 
-If you received paths to prior review feedback (reviews, inline comments, conversation), your main focus shifts: first verify the previously requested changes were addressed, and only then check for new problems introduced.
+If you received paths to prior review feedback (reviews, inline comments, conversation), it is a re-review: verify each previously requested change was addressed, and check that no new problems were introduced. Review at full scope and report what you find at honest severity — but understand the round's purpose: it exists to close the review, not restart it. A new [major] must surface; smaller new findings are input for the judge, not grounds to reopen on their own.
 
 ## Output
 

--- a/plugins/rpi/commands/review-pr.md
+++ b/plugins/rpi/commands/review-pr.md
@@ -120,7 +120,7 @@ Spawn the review subagents **in parallel** using the Task tool, each by its own 
 
 **Why subagents review at all: they are fresh eyes.** Each reviewer arrives with zero knowledge of this PR beyond its own charter — that absence of bias is exactly what finds the gaps and blind spots you've already rationalized past. **Never add interpretation, summaries, or framing** — no "this looks consistent with…", no digest of what the metadata showed you. A reviewer fed your conclusions ratifies them instead of auditing the code; the bare prompt is what keeps the eyes fresh.
 
-If re-review mode is activated, each subagent also receives the paths to `/tmp/pr_<NUMBER>_reviews.json`, `/tmp/pr_<NUMBER>_inline_comments.json`, and `/tmp/pr_<NUMBER>_conversation.json` (or `.txt` when `| toon` was applied at extraction — prefer token-efficient artifact formats) — receiving prior-feedback paths is what shifts a reviewer's focus to verifying fixes first; no mode flag is needed.
+If re-review mode is activated, each subagent also receives the paths to `/tmp/pr_<NUMBER>_reviews.json`, `/tmp/pr_<NUMBER>_inline_comments.json`, and `/tmp/pr_<NUMBER>_conversation.json` (or `.txt` when `| toon` was applied at extraction — prefer token-efficient artifact formats) — receiving prior-feedback paths is what tells a reviewer it is a re-review; no mode flag is needed.
 
 **Spawn every reviewer whose domain exists in this repo — coverage is the point.** The full roster is the default; an omission needs a reason: the test-framework twin that doesn't apply (`rpi:review-tests-rspec` for RSpec repos, `rpi:review-tests-minitest` for minitest repos — pick the one matching the stack, never both), a domain genuinely absent from the repo (no Rails reviewer in a non-Rails project), or an explicit user skip. Never trim the roster for brevity or token thrift — an unreviewed domain is a silent LGTM.
 
@@ -190,6 +190,8 @@ Then compile:
 Determine verdict:
 - **REQUEST_CHANGES** — If any [major] or multiple [minor] concerns are accepted
 - **APPROVE** — If no significant concerns survive the judgment filter
+
+In re-review, REQUEST_CHANGES when a previously requested change is unaddressed or a new [major] is accepted. A couple of new [minor]/[nit] findings don't restart the cycle — carry them in the review body as non-blocking suggestions. (A pile-up of accepted minors is judgment territory, as always.)
 
 ### Step 7: Present Review (review / re-review)
 


### PR DESCRIPTION
## Problem

Since the reviewers became static agents (#35), re-review mode stopped converging. The old orchestrator-written prompts narrowed round 2 to "primary: verify fixes, secondary: new problems"; the static charters instead run their full audit every round with a verification preamble bolted on. A fresh full audit always finds something new — even in code unchanged since round 1 — and the round-agnostic verdict rule turned every new nit into another REQUEST_CHANGES. Tickets got stuck in re-review loops.

## Change

Scope stays, consequence changes — reviewers keep full eyes; the round's purpose and the blocking threshold move.

- **Reviewer charters** (all seven, `### Prior feedback`): prior-feedback paths now frame the round as a re-review — verify each requested change, check nothing new was introduced, review at full scope and honest severity, but the round exists to close the review, not restart it. A new [major] must surface; smaller findings are input for the judge, not grounds to reopen.
- **Judge layer** (`review-pr.md` Step 6): in re-review, REQUEST_CHANGES only for an unaddressed prior request or an accepted new [major]. A couple of new minors/nits ride along as non-blocking suggestions; a pile-up of accepted minors stays judgment territory.
- **Step 5-a** wording aligned: prior-feedback paths are "what tells a reviewer it is a re-review".
- rpi `1.12.0 → 1.12.1` in both manifests.

## Test plan

- All seven agents carry the identical new `### Prior feedback` text (single-source replace, asserted one match per file).
- Manual: run `/rpi:review-pr re-review` on a PR with prior feedback; expect fix verification plus non-blocking notes instead of a fresh REQUEST_CHANGES over nits.