### PR TITLE
fix(rpi): let the judge read the record before judging

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -59,7 +59,7 @@
     {
       "name": "rpi",
       "description": "RPI workflow: Research, Planning, Implementation with context engineering",
-      "version": "1.12.1",
+      "version": "1.12.2",
       "source": "./plugins/rpi",
       "category": "workflow"
     }

--- a/plugins/rpi/.claude-plugin/plugin.json
+++ b/plugins/rpi/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rpi",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "RPI workflow: Research, Planning, Implementation. Context engineering system with structured agents and commands for AI-assisted development.",
   "author": {
     "name": "hoblin"

--- a/plugins/rpi/commands/review-pr.md
+++ b/plugins/rpi/commands/review-pr.md
@@ -166,7 +166,7 @@ Spawn **rpi:codebase-analyzer** and **rpi:codebase-pattern-finder** in parallel.
 
 After all subagents complete, compile findings into a unified review.
 
-Read `/tmp/pr_<NUMBER>_diff.txt` now, plus the prior-feedback artifacts from "Step 1: Gather PR Metadata" if the mode saved any. Withholding them is what kept the spawn unbiased; judging without them is guessing at what the code does and at what a previous round already settled.
+Read `/tmp/pr_<NUMBER>_diff.txt` now, plus the prior-feedback artifacts from "Step 1: Gather PR Metadata" if the mode saved any. An informed decision requires you to know the full context of the PR.
 
 **Critical: Subagents are pattern matchers. You are the judgment layer.** Subagents are designed to be paranoid and thorough — they flag everything that matches their heuristics. Your job is to filter their output, not rubber-stamp it. A [major] from a subagent can become a [nit] or be dropped entirely after applying judgment.
 

--- a/plugins/rpi/commands/review-pr.md
+++ b/plugins/rpi/commands/review-pr.md
@@ -24,9 +24,9 @@ Examples:
 
 ## Process
 
-Your role is **orchestrator and judge**, not doer. You collect artifacts, delegate analysis to subagents, and apply judgment to their output. The subagents read the code and comments — you decide what to do about their findings. Your context budget is reserved for judgment, not for reading raw data.
+Your role is **orchestrator and judge**, not doer. You collect artifacts, delegate analysis to subagents, and apply judgment to their output. The subagents read the code and comments — you decide what to do about their findings.
 
-Steps are sequential — later steps depend on earlier results. Complete each step and wait for its results before starting the next. Skipping ahead without subagent results means the judgment layer in "Step 6: Merge Results" has nothing to work with. Only parallelize where explicitly marked (e.g., "spawn in parallel").
+Steps are sequential — later steps depend on earlier results. Complete each step and wait for its results before starting the next. Skipping ahead without subagent results means the judgment layer in "Step 6: Judge Findings" has nothing to work with. Only parallelize where explicitly marked (e.g., "spawn in parallel").
 
 ### Step 1: Gather PR Metadata
 
@@ -36,7 +36,7 @@ gh pr view <PR_NUMBER> --json number,title,body,url,headRefName,baseRefName
 
 If re-review or address-feedback mode is activated, also save all existing review feedback to `/tmp/`:
 
-**Do not read these files — pass them to subagents by path only.** The subagents will read and analyze the content. Reading them here would consume context budget that the main agent needs for judgment in "Step 6: Merge Results".
+**Do not read these files — pass them to subagents by path only.** The subagents will read and analyze the content.
 ```bash
 # Review verdicts and bodies (APPROVED, CHANGES_REQUESTED, COMMENTED)
 gh api repos/<OWNER>/<REPO>/pulls/<PR_NUMBER>/reviews \
@@ -58,7 +58,7 @@ If `toon` is available, pipe each extraction through it and save as `.txt` inste
 
 ### Step 2: Fetch and Save Diff
 
-Checkout the PR branch locally and generate the diff. Save it to `/tmp/` — only subagents will read it.
+Checkout the PR branch locally and generate the diff. Save it to `/tmp/`.
 
 ```bash
 git fetch origin
@@ -155,16 +155,18 @@ Historical context: <thoughts-analyzer task output file path>
 
 ### Step 5-b: Spawn Codebase Research Subagents (address-feedback)
 
-Unless address-feedback mode is activated, skip to "Step 6: Merge Results" below.
+Unless address-feedback mode is activated, skip to "Step 6: Judge Findings" below.
 
 Spawn **rpi:codebase-analyzer** and **rpi:codebase-pattern-finder** in parallel. Each receives:
 - Paths to comment files and diff file in `/tmp/`
 - Historical context (from "Step 4: Gather Historical Context")
 - Any additional instructions from the user's input
 
-### Step 6: Merge Results
+### Step 6: Judge Findings
 
 After all subagents complete, compile findings into a unified review.
+
+Read `/tmp/pr_<NUMBER>_diff.txt` now, plus the prior-feedback artifacts from "Step 1: Gather PR Metadata" if the mode saved any. Withholding them is what kept the spawn unbiased; judging without them is guessing at what the code does and at what a previous round already settled.
 
 **Critical: Subagents are pattern matchers. You are the judgment layer.** Subagents are designed to be paranoid and thorough — they flag everything that matches their heuristics. Your job is to filter their output, not rubber-stamp it. A [major] from a subagent can become a [nit] or be dropped entirely after applying judgment.
 
@@ -298,5 +300,5 @@ Done when all comments are answered and re-review is requested.
 
 - Focus only on changed lines, not surrounding unchanged code
 - Provide concrete fix suggestions for [major] issues
-- The main agent must never read the diff file — only subagents read it
+- The main agent must not read the diff file before Step 6
 - Pass additional instructions from user input through to all subagents


### PR DESCRIPTION
## Problem to solve

A re-review returns REQUEST_CHANGES on findings a previous round already settled, so a mergeable PR pays for another cycle and the author is asked to re-defend decisions that were accepted.

Two shapes of settled, both observed in one live run: a finding whose previous review **offered several acceptable resolutions** and the author took one, and a finding the author **declined with a stated rationale** in the response comment. Both were re-raised as blocking.

## Reproduction

1. Run `/rpi:review-pr re-review <PR>` on a PR whose author has pushed fixes and answered the prior round.
2. `Step 1` saves reviews / inline comments / conversation to `/tmp` under **"Do not read these files"**.
3. Reviewers receive the paths. Each treats prior feedback as more ground to hunt over and re-raises what it finds — a reviewer has no way to know an item was adjudicated.
4. `Step 6` weighs their output.

Expected: settled findings are recognised and carried as non-blocking. Actual: they block, and the judge sees several independent "confirmations" of each.

## Root cause

**Nothing ever lifts the Step 1 ban.** The ban is correct where it sits — the spawn has to stay free of the orchestrator's conclusions, or the reviewers stop being independent. But `Step 6` then asks whether a previously requested change was addressed while the record that answers it is still closed. The judge cannot distinguish *ignored* from *answered*, so everything reads as ignored.

**The step is named for a job it stopped doing.** `Merge Results` is the original name from the first version of the command, when the step was four clerical operations — group, dedupe, add suggestions, preserve refs — and the verdict lived in its own `Step 4: Deliver Verdict`. `f1f0270` moved the judgment layer in and folded the verdict up; the name never followed. "Merge Results" reads as *combine what you already hold*. Nothing in that name prompts going to **get** anything, which is why no read instruction ever found a home there.

## Solution

- `Step 6: Merge Results` → **`Step 6: Judge Findings`**, with its three cross-references updated.
- The step reads `/tmp/pr_<NUMBER>_diff.txt` and any prior-feedback artifacts before weighing findings.
- `Guidelines`: "must never read the diff file" → "must not read the diff file before Step 6". `Step 2` drops "only subagents will read it". Both contradicted the new instruction.
- Context-budget rationale removed from the role statement and from `Step 1`.

## Why keep the Step 1 ban?

It is what makes spawning reviewers worth anything. Fresh eyes find what the orchestrator already rationalised past; a reviewer fed conclusions ratifies them instead of auditing the code. The ban was never wrong — it just ran past the point where it helps.

## Why drop the context-budget rationale?

It was true at 200k and is now the argument *against* a read the judge is required to make. An instruction that argues with itself is worse than one with no rationale at all.

## Verification

`grep` over `plugins/` returns no `Merge Results`, `context budget`, or `only subagents` references. `rpi` bumped to `1.12.2` in `plugin.json` and `marketplace.json`.